### PR TITLE
Endpoint for raw now_playing data + revamped the whole app.py code

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyInterpreterInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.13 (NumPy Prac)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (spotifyting-main)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/spotifyting-main.iml" filepath="$PROJECT_DIR$/.idea/spotifyting-main.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/spotifyting-main.iml
+++ b/.idea/spotifyting-main.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv1" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.11 (spotifyting-main)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/backend/test.py
+++ b/backend/test.py
@@ -10,7 +10,6 @@ from spotipy.oauth2 import SpotifyOAuth
 # ---------------- Flask Setup ----------------
 app = Flask(__name__)
 CORS(app)
-
 UPLOAD_FOLDER = "uploads"
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
@@ -85,7 +84,6 @@ def upload_zip():
         AllHistory["ms_played"] = AllHistory["ms_played"].fillna(0) / 60000
         AllHistory["ts"] = pd.to_datetime(AllHistory["ts"], errors="coerce").dt.tz_localize(None)
 
-        # Apply timeframe filter
         now = datetime.now()
         if timeframe == "30_days":
             AllHistory = AllHistory[AllHistory["ts"] >= now - timedelta(days=30)]
@@ -94,7 +92,6 @@ def upload_zip():
         elif timeframe == "1_year":
             AllHistory = AllHistory[AllHistory["ts"] >= now - timedelta(days=365)]
 
-        # Handle empty dataset
         if AllHistory.empty:
             return jsonify({"error": "No listening history in this timeframe"}), 400
 
@@ -125,17 +122,6 @@ def api_stats():
     }
 
     return jsonify(api_stats)
-
-
-# ---------------- Spotify API Raw Endpoint ----------------
-@app.route("/current_track", methods=["GET"])
-def current_track():
-    current = sp.current_playback()
-    if current:
-        return jsonify(current)
-    else:
-        return jsonify({"error": "Nothing is currently playing"}), 404
-
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/frontend/og app.py
+++ b/frontend/og app.py
@@ -1,0 +1,137 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+import pandas as pd
+import json
+from datetime import datetime, timedelta
+import os
+import zipfile
+import tempfile
+import shutil
+
+print("🚀 Starting Flask app...")
+
+app = Flask(__name__)
+CORS(app)
+
+UPLOAD_FOLDER = "uploads"
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+
+@app.route("/upload", methods=["POST"])
+def upload_zip():
+    if "file" not in request.files:
+        return jsonify({"error": "No file uploaded"}), 400
+
+    zip_file = request.files["file"]
+    timeframe = request.form.get("timeframe", "lifetime")
+
+    if not zip_file.filename.endswith(".zip"):
+        return jsonify({"error": "Only .zip files are allowed"}), 400
+
+    # Save the uploaded zip
+    zip_path = os.path.join(UPLOAD_FOLDER, zip_file.filename)
+    zip_file.save(zip_path)
+
+    # Create a temporary directory
+    temp_dir = tempfile.mkdtemp()
+
+    try:
+        with zipfile.ZipFile(zip_path, "r") as z:
+            z.extractall(temp_dir)
+
+        dfs = []
+        # Read all JSON files inside the zip
+        for root, _, files in os.walk(temp_dir):
+            for fname in files:
+                if fname.endswith(".json"):
+                    fpath = os.path.join(root, fname)
+                    try:
+                        with open(fpath, "r", encoding="utf-8") as f:
+                            data = json.load(f)
+                    except Exception as e:
+                        return jsonify({"error": f"Error parsing {fname}: {str(e)}"}), 400
+
+                    if isinstance(data, dict):
+                        dfs.append(pd.DataFrame([data]))
+                    else:
+                        dfs.append(pd.DataFrame(data))
+
+        if not dfs:
+            return jsonify({"error": "No JSON files found inside zip"}), 400
+
+        AllHistory = pd.concat(dfs, ignore_index=True)
+
+        # Ensure required columns exist
+        required_cols = [
+            "ms_played",
+            "ts",
+            "master_metadata_track_name",
+            "master_metadata_album_artist_name",
+        ]
+        for col in required_cols:
+            if col not in AllHistory.columns:
+                AllHistory[col] = None
+
+        # Convert ms_played → minutes, ts → datetime
+        AllHistory["ms_played"] = AllHistory["ms_played"].fillna(0) / 60000
+        AllHistory["ts"] = pd.to_datetime(AllHistory["ts"], errors="coerce").dt.tz_localize(None)
+
+        # Apply timeframe filter
+        now = datetime.now()
+        if timeframe == "30_days":
+            cutoff = now - timedelta(days=30)
+            AllHistory = AllHistory[AllHistory["ts"] >= cutoff]
+        elif timeframe == "6_months":
+            cutoff = now - timedelta(days=180)
+            AllHistory = AllHistory[AllHistory["ts"] >= cutoff]
+        elif timeframe == "1_year":
+            cutoff = now - timedelta(days=365)
+            AllHistory = AllHistory[AllHistory["ts"] >= cutoff]
+
+        # Handle empty dataset
+        if AllHistory.empty:
+            return jsonify({
+                "timeframe": timeframe,
+                "amount_of_tracks": 0,
+                "total_listening_hours": 0,
+                "avg_track_duration": 0,
+                "top_10_artists": {},
+                "top_10_songs": {}
+            })
+
+        # Metrics
+        amount_of_tracks = int(AllHistory["master_metadata_track_name"].count())
+        total_listening_hours = float(AllHistory["ms_played"].sum() / 60)
+        avg_track_duration = float(AllHistory["ms_played"].mean() or 0)
+
+        top_10_artists = (
+            AllHistory["master_metadata_album_artist_name"]
+            .value_counts()
+            .head(10)
+            .to_dict()
+        )
+        top_10_songs = (
+            AllHistory["master_metadata_track_name"]
+            .value_counts()
+            .head(10)
+            .to_dict()
+        )
+
+        return jsonify({
+            "timeframe": timeframe,
+            "amount_of_tracks": amount_of_tracks,
+            "total_listening_hours": round(total_listening_hours, 2),
+            "avg_track_duration": round(avg_track_duration, 2),
+            "top_10_artists": top_10_artists,
+            "top_10_songs": top_10_songs
+        })
+
+    finally:
+        # Always cleanup
+        if os.path.exists(zip_path):
+            os.remove(zip_path)
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "spotifyting-main",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
# Conflicts:
#	backend/app.py
#	backend/venv/bin/Activate.ps1
#	backend/venv/bin/f2py
#	backend/venv/bin/flask
#	backend/venv/bin/numpy-config
#	backend/venv/bin/pip
#	backend/venv/bin/pip3
#	backend/venv/bin/pip3.9
#	backend/venv/bin/python
#	backend/venv/bin/python3
#	backend/venv/bin/python3.9
#	backend/venv/bin/python3.9~fc2aae9 (Initial commit with local changes) #	backend/venv/bin/python3~fc2aae9 (Initial commit with local changes) #	backend/venv/bin/python~fc2aae9 (Initial commit with local changes) #	backend/venv/lib/python3.9/site-packages/MarkupSafe-3.0.2.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/blinker-1.9.0.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/click-8.1.8.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/flask-3.1.2.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/flask_cors-6.0.1.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/importlib_metadata-8.7.0.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/itsdangerous-2.2.0.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/jinja2-3.1.6.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/markupsafe/_speedups.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy-2.0.2.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/numpy/_core/_multiarray_tests.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/_core/_multiarray_umath.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/_core/_operand_flag_tests.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/_core/_rational_tests.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/_core/_simd.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/_core/_struct_ufunc_tests.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/_core/_umath_tests.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/f2py/crackfortran.py #	backend/venv/lib/python3.9/site-packages/numpy/f2py/f2py2e.py #	backend/venv/lib/python3.9/site-packages/numpy/f2py/rules.py #	backend/venv/lib/python3.9/site-packages/numpy/fft/_pocketfft_umath.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/linalg/_umath_linalg.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/linalg/lapack_lite.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/random/_bounded_integers.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/random/_common.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/random/_generator.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/random/_mt19937.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/random/_pcg64.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/random/_philox.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/random/_sfc64.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/random/bit_generator.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/random/mtrand.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/numpy/testing/print_coercion_tables.py #	backend/venv/lib/python3.9/site-packages/pandas-2.3.2.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/pandas/_libs/algos.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/arrays.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/byteswap.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/groupby.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/hashing.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/hashtable.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/index.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/indexing.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/internals.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/interval.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/join.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/json.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/lib.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/missing.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/ops.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/ops_dispatch.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/pandas_datetime.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/pandas_parser.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/parsers.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/properties.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/reshape.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/sas.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/sparse.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/testing.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslib.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/base.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/ccalendar.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/conversion.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/dtypes.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/fields.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/nattype.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/np_datetime.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/offsets.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/parsing.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/period.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/strptime.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/timedeltas.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/timestamps.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/timezones.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/tzconversion.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/tslibs/vectorized.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/window/aggregations.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/window/indexers.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pandas/_libs/writers.cpython-39-darwin.so #	backend/venv/lib/python3.9/site-packages/pip-21.2.4.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/pkg_resources/_vendor/pyparsing.py #	backend/venv/lib/python3.9/site-packages/python_dateutil-2.9.0.post0.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/pytz-2025.2.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/setuptools-58.0.4.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/setuptools/_vendor/pyparsing.py #	backend/venv/lib/python3.9/site-packages/six-1.17.0.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/tzdata-2025.2.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/werkzeug-3.1.3.dist-info/RECORD #	backend/venv/lib/python3.9/site-packages/zipp-3.23.0.dist-info/RECORD #	frontend/spotifyting_frontend/index.html
#	frontend/spotifyting_frontend/package-lock.json
#	frontend/spotifyting_frontend/package.json
#	frontend/spotifyting_frontend/src/Home.jsx
#	frontend/spotifyting_frontend/src/index.css